### PR TITLE
Cleaning up the comparison code to do xls comparisons in unicode.

### DIFF
--- a/table_differ/td_table.py
+++ b/table_differ/td_table.py
@@ -1,3 +1,4 @@
+import unicodedata
 class TdTable:
 
     def __init__(self):
@@ -9,7 +10,7 @@ class TdTable:
     def get_value(self, row_index, col_index, as_str=True):
         v = self._rows[row_index][col_index]
         if as_str:
-            v = str(v)
+            v = unicodedata.normalize('NFKD', unicode(v)).encode('ascii', 'ignore')
         return v
 
     @property

--- a/table_differ/td_table.py
+++ b/table_differ/td_table.py
@@ -10,7 +10,11 @@ class TdTable:
     def get_value(self, row_index, col_index, as_str=True):
         v = self._rows[row_index][col_index]
         if as_str:
+<<<<<<< HEAD
+            v = unicode(v)
+=======
             v = unicodedata.normalize('NFKD', unicode(v)).encode('ascii', 'ignore')
+>>>>>>> ef3fe337d89f49305b59c6ab96559571be4f4314
         return v
 
     @property


### PR DESCRIPTION
Comparing xls spreadsheets with unicode non-ascii characters were crashing the comparison, preventing us from comparing spreadsheets with non-ascii characters.  If we do the comparison in unicode instead of char, we can both see the exact text as it is in the spreadsheet, and do xls comparisons with arbitrary unicode in it.
